### PR TITLE
Set link colors to black

### DIFF
--- a/_extensions/asce/_extension.yml
+++ b/_extensions/asce/_extension.yml
@@ -18,6 +18,12 @@ contributes:
         title-delim: "." 
     pdf:
       pdf-engine: pdflatex
+      hyperrefoptions:
+        - hidelinks
+        - linkcolor=black
+      linkcolor: black
+      citecolor: black
+      urlcolor: black
       header-includes: |
         \usepackage[figurename=Fig.,labelfont=bf,labelsep=period]{caption}
         \usepackage{newtxtext,newtxmath}


### PR DESCRIPTION
I had a paper rejected by the copy editor upon submission because links to citations and other elements appeared in blue text. This sets these colors to be black.